### PR TITLE
Add getCustomText method for templating

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -184,6 +184,21 @@ class Link extends Model
   }
 
   /**
+   * Try to use provided custom text or field default.
+   * Allows user to specify a fallback string if the custom text and default are not set.
+   *
+   * @param string $fallbackText
+   * @return void
+   */
+  public function getCustomText($fallbackText = "Learn More") {
+    if ($this->allowCustomText && !empty($this->customText)) {
+      return $this->customText;
+    }
+
+    return $this->defaultText ? $this->defaultText : $fallbackText;
+  }
+
+  /**
    * @return null|string
    */
   public function getUrl() {


### PR DESCRIPTION
This method will only try to grab custom text or the field default text, but also allows a user provided fallback in case those settings are not provided.