### PR TITLE
Add custom link type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You can use the following accessors to get the different properties of the link:
 {{ item.myLinkField.getUrl() }}
 {{ item.myLinkField.hasElement() }}
 {{ item.myLinkField.isEmpty() }}
+{{ item.myLinkField.getCustomText() }}
 ```
 
 Use the `getLink` utility function to render a full html link:

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,6 +86,11 @@ class Plugin extends \craft\base\Plugin
         'displayGroup' => 'Input fields',
         'inputType'    => 'url'
       ]),
+      'custom' => new InputLinkType([
+        'displayName'  => 'Custom',
+        'displayGroup' => 'Input fields',
+        'inputType'    => 'text'
+      ]),
       'email' => new InputLinkType([
         'displayName'  => 'Mail',
         'displayGroup' => 'Input fields',


### PR DESCRIPTION
Add a custom link type to allow for freeform urls such as hash urls and relative paths.

Update documentation to include the `getCustomText` method