### PR TITLE
Better CraftQL integration

### DIFF
--- a/src/utilities/CraftQLListener.php
+++ b/src/utilities/CraftQLListener.php
@@ -7,7 +7,6 @@ use craft\elements\Asset;
 use craft\elements\Entry;
 use markhuot\CraftQL\Builders\Schema;
 use markhuot\CraftQL\Events\GetFieldSchema;
-use GraphQL\Type\Definition\InputObjectType;
 use typedlinkfield\fields\LinkField;
 use typedlinkfield\models\ElementLinkType;
 use typedlinkfield\models\Link;

--- a/src/utilities/CraftQLListener.php
+++ b/src/utilities/CraftQLListener.php
@@ -69,7 +69,7 @@ class CraftQLListener {
     $link = $object->addStringField('link');
     $link->addStringArgument('text');
     $link->resolve(function($link, $args) {
-        return $link instanceof Link ? (string) $link->getLink($args['text']) : '';
+        return $link instanceof Link ? (string) $link->getLink($args['text'] ?? null) : '';
     });
 
     $object->addStringField('customText');

--- a/src/utilities/CraftQLListener.php
+++ b/src/utilities/CraftQLListener.php
@@ -2,10 +2,12 @@
 
 namespace typedlinkfield\utilities;
 
+use craft\elements\Category;
 use craft\elements\Asset;
 use craft\elements\Entry;
 use markhuot\CraftQL\Builders\Schema;
 use markhuot\CraftQL\Events\GetFieldSchema;
+use GraphQL\Type\Definition\InputObjectType;
 use typedlinkfield\fields\LinkField;
 use typedlinkfield\models\ElementLinkType;
 use typedlinkfield\models\Link;
@@ -20,9 +22,7 @@ class CraftQLListener {
    * @var array
    */
   static $QL_TYPES = [
-    // Category seems to be deprecated and GlobalSet has no interface we can refer to:
-    // Category::class  => \markhuot\CraftQL\Types\CategoryInterface::class,
-    // GlobalSet::class => \markhuot\CraftQL\Types\GlobalsSet::class,
+    Category::class  => \markhuot\CraftQL\Types\CategoryInterface::class,
     Asset::class     => \markhuot\CraftQL\Types\VolumeInterface::class,
     Entry::class     => \markhuot\CraftQL\Types\EntryInterface::class,
   ];
@@ -67,11 +67,16 @@ class CraftQLListener {
       $types[] = $linkName;
     }
 
-    $object->addBooleanField('allowCustomText');
-    $object->addBooleanField('allowTarget');
+    $link = $object->addStringField('link');
+    $link->addStringArgument('text');
+    $link->resolve(function($link, $args) {
+        return $link instanceof Link ? (string) $link->getLink($args['text']) : '';
+    });
+
     $object->addStringField('customText');
     $object->addStringField('defaultText');
     $object->addStringField('target');
+    $object->addStringField('text');
     $object->addEnumField('type')->values($types);
     $object->addStringField('url')->resolve(function($link) {
       return $link instanceof Link ? $link->getUrl() : '';


### PR DESCRIPTION
- Bring back Category (supported by CraftQL now)
- Add resolved `text` field
- Add `link` field
  - Accepts `text` arg override
  - Ultimately, this should also include an `attributes` object argument to pass/override any html attrs (just didn't have time)
- Remove allowCustomText and allowTarget, as they didn't seem relevant to query for