### PR TITLE
Add sites type

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,6 +117,10 @@ class Plugin extends \craft\base\Plugin
         'displayGroup' => 'Craft CMS',
         'elementType'  => \craft\elements\User::class
       ]),
+      'site' => new SiteLinkType([
+        'displayGroup' => 'Craft CMS',
+        'displayName'  => 'Site',
+      ]),
     ];
 
     // Add craft commerce elements

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,7 @@ use typedlinkfield\events\LinkTypeEvent;
 use typedlinkfield\fields\LinkField;
 use typedlinkfield\models\ElementLinkType;
 use typedlinkfield\models\InputLinkType;
+use typedlinkfield\models\SiteLinkType;
 use typedlinkfield\models\LinkTypeInterface;
 use yii\base\Event;
 

--- a/src/models/SiteLinkType.php
+++ b/src/models/SiteLinkType.php
@@ -84,12 +84,12 @@ class SiteLinkType extends Model implements LinkTypeInterface
     $settings   = $field->getLinkTypeSettings($linkTypeName, $this);
     $siteIds    = $settings['sites'];
     $isSelected = $value->type === $linkTypeName;
-    $value = $isSelected ? $value : null;
+    $selectedSite = $isSelected ? $this->getSite($value) : null;
     $selectFieldOptions = [
       'id'      => $field->handle . '-' . $linkTypeName,
       'name'    => $field->handle . '[' . $linkTypeName . ']',
       'options' => $this->getSiteOptions($siteIds),
-      'value'   => $value->value,
+      'value'   => $selectedSite->id ?? null,
     ];
 
     try {

--- a/src/models/SiteLinkType.php
+++ b/src/models/SiteLinkType.php
@@ -126,7 +126,7 @@ class SiteLinkType extends Model implements LinkTypeInterface
         'settings'     => $field->getLinkTypeSettings($linkTypeName, $this),
         'elementName'  => $this->getDisplayName(),
         'linkTypeName' => $linkTypeName,
-        'siteOptions'      => $this->getSiteOptions(),
+        'siteOptions'  => $this->getSiteOptions(),
       ]);
     } catch (\Throwable $exception) {
       return Html::tag('p', \Craft::t(
@@ -141,8 +141,14 @@ class SiteLinkType extends Model implements LinkTypeInterface
    * @return array
    */
   protected function getSiteOptions($siteIds = null) {
+    if ($siteIds === '*') {
+      $siteIds = null;
+    } elseif ($siteIds === '') {
+      $siteIds = [];
+    }
+
     $options = array_map(function($site) use ($siteIds) {
-      if (!$site->hasUrls || ($siteIds && !in_array($site->id, $siteIds))) {
+      if (!$site->hasUrls || (is_array($siteIds) && !in_array($site->id, $siteIds))) {
         return null;
       }
 

--- a/src/models/SiteLinkType.php
+++ b/src/models/SiteLinkType.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace typedlinkfield\models;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\helpers\Html;
+use craft\models\Site;
+use typedlinkfield\fields\LinkField;
+use yii\base\Model;
+
+/**
+ * Class SiteLinkType
+ * @package typedlinkfield\models
+ */
+class SiteLinkType extends Model implements LinkTypeInterface
+{
+  /**
+   * @var string
+   */
+  public $displayGroup = 'Common';
+  public $displayName;
+
+  /**
+   * SiteLinkType constructor.
+   * @param string|array $displayName
+   * @param array $options
+   */
+  public function __construct($displayName, array $options = []) {
+    if (is_array($displayName)) {
+       $options = $displayName;
+    } else {
+       $options['displayName'] = $displayName;
+    }
+
+    parent::__construct($options);
+  }
+
+
+  /**
+   * @return array
+   */
+  public function getDefaultSettings(): array {
+    return [
+      'sites' => '*',
+    ];
+  }
+
+  /**
+   * @return string
+   */
+
+    public function getDisplayName(): string {
+     return \Craft::t('typedlinkfield', $this->displayName);
+    }
+
+  /**
+   * @return string
+   */
+   public function getDisplayGroup(): string {
+     return \Craft::t('typedlinkfield', $this->displayGroup);
+   }
+
+  /**
+   * @param Link $link
+   * @return null|Site
+   */
+  public function getSite(Link $link) {
+    if ($this->isEmpty($link)) {
+      return null;
+    }
+
+    return Craft::$app->getSites()->getSiteById($link->value);
+  }
+
+  /**
+   * @param string $linkTypeName
+   * @param LinkField $field
+   * @param Link $value
+   * @param ElementInterface $element
+   * @return string
+   */
+  public function getInputHtml(string $linkTypeName, LinkField $field, Link $value, ElementInterface $element): string {
+    $settings   = $field->getLinkTypeSettings($linkTypeName, $this);
+    $siteIds    = $settings['sites'];
+    $isSelected = $value->type === $linkTypeName;
+    $value = $isSelected ? $value : null;
+    $selectFieldOptions = [
+      'id'      => $field->handle . '-' . $linkTypeName,
+      'name'    => $field->handle . '[' . $linkTypeName . ']',
+      'options' => $this->getSiteOptions($siteIds),
+      'value'   => $value->value,
+    ];
+
+    try {
+      return \Craft::$app->view->renderTemplate('typedlinkfield/_input-select', [
+        'isSelected'         => $isSelected,
+        'linkTypeName'       => $linkTypeName,
+        'selectFieldOptions' => $selectFieldOptions,
+      ]);
+    } catch (\Throwable $exception) {
+      return Html::tag('p', \Craft::t(
+        'typedlinkfield',
+        'Error: Could not render the template for the field `{name}`.',
+        [ 'name' => $this->getDisplayName() ]
+      ));
+    }
+  }
+
+  /**
+   * @param mixed $value
+   * @return mixed
+   */
+  public function getLinkValue($value) {
+    return $value ?? null;
+  }
+
+  /**
+   * @param string $linkTypeName
+   * @param LinkField $field
+   * @return string
+   */
+  public function getSettingsHtml(string $linkTypeName, LinkField $field): string {
+    try {
+      return \Craft::$app->view->renderTemplate('typedlinkfield/_settings-site', [
+        'settings'     => $field->getLinkTypeSettings($linkTypeName, $this),
+        'elementName'  => $this->getDisplayName(),
+        'linkTypeName' => $linkTypeName,
+        'siteOptions'      => $this->getSiteOptions(),
+      ]);
+    } catch (\Throwable $exception) {
+      return Html::tag('p', \Craft::t(
+        'typedlinkfield',
+        'Error: Could not render the template for the field `{name}`.',
+        [ 'name' => $this->getDisplayName() ]
+      ));
+    }
+  }
+
+  /**
+   * @return array
+   */
+  protected function getSiteOptions($siteIds = null) {
+    $options = array_map(function($site) use ($siteIds) {
+      if (!$site->hasUrls || ($siteIds && !in_array($site->id, $siteIds))) {
+        return null;
+      }
+
+      return [
+        'value' => $site->id,
+        'label' => $site->name
+      ];
+    }, Craft::$app->getSites()->getAllSites());
+
+    return array_filter($options);
+  }
+
+  /**
+   * @param Link $link
+   * @return null|string
+   */
+  public function getText(Link $link) {
+    $site = $this->getSite($link);
+    if (is_null($site)) {
+      return null;
+    }
+
+    return (string)$site;
+  }
+
+  /**
+   * @param Link $link
+   * @return null|string
+   */
+  public function getUrl(Link $link) {
+    $site = $this->getSite($link);
+    if (is_null($site)) {
+      return null;
+    }
+
+    return Craft::getAlias($site->baseUrl);
+  }
+
+  /**
+   * @param Link $link
+   * @return bool
+   */
+  public function isEmpty(Link $link): bool {
+    if (is_string($link->value)) {
+      return trim($link->value) === '';
+    }
+
+    return true;
+  }
+
+  /**
+   * @param LinkField $field
+   * @param Link $link
+   * @return array|null
+   */
+  public function validateValue(LinkField $field, Link $link) {
+    return null;
+  }
+
+
+  /**
+   * @param Link $link
+   * @return ElementInterface|null
+   */
+  public function getElement(Link $link) {
+    return null;
+  }
+
+  /**
+   * @param Link $link
+   * @return ElementInterface|null
+   */
+  public function hasElement(Link $link): bool {
+      return false;
+  }
+
+}

--- a/src/templates/_input-select.twig
+++ b/src/templates/_input-select.twig
@@ -1,0 +1,5 @@
+{% import "_includes/forms" as forms %}
+
+<div class="linkfield--typeOption {{ linkTypeName }}{{ isSelected ? '' : ' hidden' }}">
+  {{ forms.select(selectFieldOptions) }}
+</div>

--- a/src/templates/_settings-site.twig
+++ b/src/templates/_settings-site.twig
@@ -1,0 +1,11 @@
+{% import "_includes/forms" as forms %}
+
+{{ forms.checkboxSelectField({
+  label: 'Sites'|t('typedlinkfield'),
+  instructions: 'Select the available sites.'|t('typedlinkfield'),
+  id: 'typeSettings-'~linkTypeName~'-sites',
+  name: 'typeSettings['~linkTypeName~'][sites]',
+  options: siteOptions,
+  values: settings.sites ?? null,
+  showAllOption: true,
+})}}


### PR DESCRIPTION
This adds a core "sites" type, for selecting a Craft base site URL.

- only sites with "This site has its own base URL" option checked are available
- aliases are resolved, so site urls with `@web/` will still return a full URL.