### PR TITLE
Fix non-json strings issue

### DIFF
--- a/src/fields/LinkField.php
+++ b/src/fields/LinkField.php
@@ -112,10 +112,11 @@ class LinkField extends Field
       'owner'     => $element,
     ];
 
-    if (is_string($value) && $parsedValue = Json::decode($value, true)) {
+    if (is_string($value)) {
       // If value is a string we are loading the data from the database
-      $attr += Json::decode($parsedValue, true);
-
+      try {
+        $attr += Json::decode($value, true);
+      } catch (\Exception $e) {}
     } else if (is_array($value) && isset($value['isCpFormData'])) {
       // If it is an array and the field `isCpFormData` is set, we are saving a cp form
       $attr += [

--- a/src/fields/LinkField.php
+++ b/src/fields/LinkField.php
@@ -117,6 +117,7 @@ class LinkField extends Field
       try {
         $attr += Json::decode($value, true);
       } catch (\Exception $e) {}
+      
     } else if (is_array($value) && isset($value['isCpFormData'])) {
       // If it is an array and the field `isCpFormData` is set, we are saving a cp form
       $attr += [

--- a/src/fields/LinkField.php
+++ b/src/fields/LinkField.php
@@ -112,9 +112,9 @@ class LinkField extends Field
       'owner'     => $element,
     ];
 
-    if (is_string($value)) {
+    if (is_string($value) && $parsedValue = Json::decode($value, true)) {
       // If value is a string we are loading the data from the database
-      $attr += Json::decode($value, true);
+      $attr += Json::decode($parsedValue, true);
 
     } else if (is_array($value) && isset($value['isCpFormData'])) {
       // If it is an array and the field `isCpFormData` is set, we are saving a cp form
@@ -128,7 +128,7 @@ class LinkField extends Field
         'value'       => $this->getLinkValue($value)
       ];
 
-    } elseif (is_array($value)) {
+    } else if (is_array($value)) {
       // Finally, if it is an array it is a serialized value
       $attr = [
         'owner' => $element,


### PR DESCRIPTION
When creating a new field we get the following error. Apparently a no-JSON string gets passed. 
![bildschirmfoto 2018-12-12 um 14 09 40](https://user-images.githubusercontent.com/6382364/49872053-2f3d0b00-fe18-11e8-877c-ea489bba2192.png)
