### PR TITLE
Modify URL validation to accept non-ASCII characters

### DIFF
--- a/src/models/InputLinkType.php
+++ b/src/models/InputLinkType.php
@@ -259,6 +259,7 @@ class InputLinkType extends Model implements LinkTypeInterface
         break;
 
       case('url'):
+        $value = idn_to_ascii($value,IDNA_NONTRANSITIONAL_TO_ASCII,INTL_IDNA_VARIANT_UTS46);
         if (!filter_var($value, FILTER_VALIDATE_URL)) {
           return [\Craft::t('typedlinkfield', 'Please enter a valid url.'), []];
         }


### PR DESCRIPTION
Domains containing non-ASCII characters are rejected in the URL validator 

https://github.com/sebastian-lenz/craft-linkfield/blob/ec8ffee6ecac06ed4bd5bb3caec01675da15d334/src/models/InputLinkType.php#L262

As the docs for FILTER_VALIDATE_URL state:

> The function will only find ASCII URLs to be valid; internationalized domain names (containing non-ASCII characters) will fail.

I'm passing the url first through idn_to_ascii() to convert to a punycode url

https://www.php.net/manual/en/function.idn-to-ascii.php

So as an example, a domain such as `http://www.tästdomäin.de` will now be valid as it is internally first converted to `http://www.xn--tstdomin-0zaf.de` before validation.

The URL is finally still saved to DB in the original form including the Unicode chars, which is not valid by itself in browsers as a link. Users of the plugin thus must take care themselves to convert that as needed and write the punycode URL to href="" attributes, for example.