### PR TITLE
fallbackText should be null to allow to run checks and override it wi…

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -340,11 +340,12 @@ class Link extends Model
   /**
    * Try to use provided custom text or field default.
    * Allows user to specify a fallback string if the custom text and default are not set.
+   * If the custom text isn't set we don't need to parse anything, so it's overrideable with custom fields.
    *
    * @param string $fallbackText
    * @return string
    */
-  public function getCustomText($fallbackText = "Learn More") {
+  public function getCustomText($fallbackText = null) {
     if ($this->getAllowCustomText() && !empty($this->customText)) {
       return $this->customText;
     }


### PR DESCRIPTION
This PR is mainly to change the behaviour of the `{{ entry.linkField.getText() }}` when the custom text isn't set.

Instead of displaying "Learn More" as the default text it is preferable to just display nothing instead if the user selected the ability to add custom Text. This will allow the user through templating to do things like

```
{% if not entry.linkField.getText() %}
  {{ entry.customField }}
{% endif %}
```

This is in my opinion much more favourable behaviour than having to do

```
{% if entry.linkField.getText() == 'Learn More' %}
  {{ entry.customField }}
{% endif %}
```

Because for a custom Text a field might actually need the text "Learn More" and this would be overwritten.