### PR TITLE
Set enableAllLinkTypes for existing entries with specific link types

### DIFF
--- a/src/migrations/m190417_202153_migrateDataToTable.php
+++ b/src/migrations/m190417_202153_migrateDataToTable.php
@@ -182,6 +182,8 @@ class m190417_202153_migrateDataToTable extends Migration
       $settings['typeSettings'] = array();
     }
 
+    $settings['enableAllLinkTypes'] = false;
+
     if (isset($settings['allowedLinkNames'])) {
       $allowedLinkNames = $settings['allowedLinkNames'];
       if (!is_array($allowedLinkNames)) {


### PR DESCRIPTION
When there is an existing entry with specific link types this should get persisted in the field settings when migrating.