### PR TITLE
Fix migration having wrong column name on Craft 3.7 #164

### DIFF
--- a/src/migrations/m190417_202153_migrateDataToTable.php
+++ b/src/migrations/m190417_202153_migrateDataToTable.php
@@ -118,7 +118,7 @@ class m190417_202153_migrateDataToTable extends Migration
    */
   private function updateLinkField(LinkField $field, string $table, string $handlePrefix = '') {
     $insertRows = [];
-    $columnName = ($field->columnPrefix ?: 'field_') . $handlePrefix . $field->handle;
+    $columnName = ($field->columnPrefix ?: 'field_') . $handlePrefix . $field->handle . ($field->columnSuffix ? '_' . $field->columnSuffix : '');
     $rows = (new Query())
       ->select([
         'elementId',


### PR DESCRIPTION
As seen on https://github.com/sebastian-lenz/craft-linkfield/issues/164 and fixed by @aaronwaldon and @alexroper