### PR TITLE
Remove enabledForSite Criteria

### DIFF
--- a/src/models/ElementLinkType.php
+++ b/src/models/ElementLinkType.php
@@ -103,7 +103,6 @@ class ElementLinkType extends Model implements LinkTypeInterface
     $elements   = $isSelected ? array_filter([$this->getElement($value)]) : null;
 
     $criteria = [
-      'enabledForSite' => null,
       'status' => null,
     ];
 


### PR DESCRIPTION
Remove enabledForSite in get elements criteria, since it's deprecated on craft 3.5 and look it removed on craft4.

Issue `[#203](https://github.com/sebastian-lenz/craft-linkfield/issues/203)`