### PR TITLE
fix: PHP8 type errors

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -369,7 +369,7 @@ class Link extends ForeignFieldModel
   /**
    * @return bool
    */
-  public function isEmpty() {
+  public function isEmpty(): bool {
     return true;
   }
 

--- a/src/models/element/ElementLink.php
+++ b/src/models/element/ElementLink.php
@@ -157,7 +157,7 @@ class ElementLink extends Link
   /**
    * @inheritDoc
    */
-  public function isEmpty() {
+  public function isEmpty(): bool {
     return empty($this->getElementUrl());
   }
 

--- a/src/models/input/InputLink.php
+++ b/src/models/input/InputLink.php
@@ -56,7 +56,7 @@ class InputLink extends Link
   /**
    * @inheritDoc
    */
-  public function isEmpty() {
+  public function isEmpty(): bool {
     return empty($this->linkedUrl);
   }
 

--- a/src/models/site/SiteLink.php
+++ b/src/models/site/SiteLink.php
@@ -61,7 +61,7 @@ class SiteLink extends Link
   /**
    * @inheritDoc
    */
-  public function isEmpty() {
+  public function isEmpty(): bool {
     return empty($this->linkedSiteId);
   }
 }


### PR DESCRIPTION
`isEmpty()` methods must have a bool return type hint