### PR TITLE
Fix migration issue

### DIFF
--- a/src/migrations/m190417_202153_migrateDataToTable.php
+++ b/src/migrations/m190417_202153_migrateDataToTable.php
@@ -105,7 +105,7 @@ class m190417_202153_migrateDataToTable extends Migration
       ->getBlockTypesByFieldId($matrixField->id);
 
     foreach ($blockTypes as $blockType) {
-      foreach ($blockType->getFields() as $field) {
+      foreach ($blockType->getCustomFields() as $field) {
         $this->updateField($field, $table, $blockType->handle.'_');
       }
     }


### PR DESCRIPTION
* Fix migration, the getFields is now renamed to getCustomFields in Craft 4, please refer to [this](https://github.com/craftcms/cms/blob/4.0/CHANGELOG.md#:~:text=craft%5Cmodels%5CFieldLayout%3A%3AgetFields()%20has%20been%20renamed%20to%20getCustomFields()).