### PR TITLE
Remove 'enabledForSite' from entry criteria

### DIFF
--- a/src/models/element/ElementLinkType.php
+++ b/src/models/element/ElementLinkType.php
@@ -223,7 +223,6 @@ class ElementLinkType extends LinkType
     }
 
     $criteria = [
-      'enabledForSite' => null,
       'status'         => null,
     ];
 


### PR DESCRIPTION
this property was deprecated in CraftCMS 3.5

See https://github.com/craftcms/cms/commit/1660ff90a3a69cec425271d47ade66523a4bd44e#diff-f94272123a3a550345c7f794061fd3664d8cff428758179dad3cfe3cc89eaef2L274-L280