### PR TITLE
add specific display name for Solspace Event elements

### DIFF
--- a/src/models/element/ElementLinkType.php
+++ b/src/models/element/ElementLinkType.php
@@ -77,6 +77,9 @@ class ElementLinkType extends LinkType
    * @inheritDoc
    */
   public function getDisplayName(): string {
+    if ($this->elementType === 'Solspace\Calendar\Elements\Event'){
+      return 'Event';
+    }
     return $this->elementType::displayName();
   }
 


### PR DESCRIPTION
It seems that the 'Solspace\Calendar\Elements\Event' element is not setting its own display name, so in the Link Field it displays as "Element" which could be confusing to the client/authors. 