### PR TITLE
Fixed a migration error that could occur when updating to Craft 4

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # Release Notes for Typed Link Field
 
+## Unreleased
+- Fix: Fixed a migration error that could occur when updating to Craft 4. (see https://github.com/sebastian-lenz/craft-linkfield/issues/230)
+
 ## 2.1.4
 - Fix: Respect the default link type setting in matrix fields (see https://github.com/sebastian-lenz/craft-linkfield/issues/221)
 - Fix: Element query executed before Craft is fully initialized (see https://github.com/sebastian-lenz/craft-linkfield/issues/231)

--- a/src/migrations/m190417_202153_migrateDataToTable.php
+++ b/src/migrations/m190417_202153_migrateDataToTable.php
@@ -132,9 +132,11 @@ class m190417_202153_migrateDataToTable extends Migration
       }
     };
 
+    // Make sure the rows actually exist in the elements table.
     $rows = (new Query())
-      ->select(['elementId', 'siteId', $columnName])
-      ->from($table)
+      ->select(['t.elementId', 't.siteId', 't.'.$columnName])
+      ->from(['t' => $table])
+      ->innerJoin(['e' => Table::ELEMENTS], '[[t.elementId]] = [[e.id]]')
       ->all();
 
     foreach ($rows as $row) {


### PR DESCRIPTION
This should fix the "Integrity constraint violation" errors reported in https://github.com/sebastian-lenz/craft-linkfield/issues/230.

The root cause is there are orphaned rows in the respective content tables (matrix, super table, etc.), that don't have a matching element id in the elements table.

This doesn't clean up the orphaned rows, but does ensure that the migration is only working with valid data.