### PR TITLE
[fix-sanitize-array] Fix a bug StringHelper::sanitizeAttributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sebastianlenz/linkfield",
+  "name": "yournextagency/craft-linkfield",
   "description": "A Craft field type for selecting links",
   "type": "craft-plugin",
   "license": "MIT",

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -17,7 +17,15 @@ class StringHelper extends \craft\helpers\StringHelper
 
   static public function sanitizeAttributes($attrs) {
     foreach ($attrs as $attr => $value) {
-      $attrs[$attr] = str_replace('\n', '', trim($value));
+      if (is_array($value)) {
+        foreach ($value as $k => $v) {
+          $value[$k] = str_replace('\n', '', trim($v));
+        }
+
+        $attrs[$attr] = array_filter($value);
+      } else {
+        $attrs[$attr] = str_replace('\n', '', trim($value));
+      }
     }
     return $attrs;
   }

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -14,4 +14,11 @@ class StringHelper extends \craft\helpers\StringHelper
   static public function decodeMb4(string $str): string {
     return preg_replace_callback('/&#x[0-9A-Fa-f]+;/', fn($match) => self::htmlDecode($match[0]), $str);
   }
+
+  static public function sanitizeAttributes($attrs) {
+    foreach ($attrs as $attr => $value) {
+      $attrs[$attr] = str_replace('\n', '', trim($value));
+    }
+    return $attrs;
+  }
 }

--- a/src/migrations/m190417_202153_migrateDataToTable.php
+++ b/src/migrations/m190417_202153_migrateDataToTable.php
@@ -12,6 +12,7 @@ use craft\helpers\Json;
 use lenz\linkfield\fields\LinkField;
 use lenz\linkfield\records\LinkRecord;
 use verbb\supertable\fields\SuperTableField;
+use Yii;
 
 /**
  * m190417_202153_migrateDataToTable migration.
@@ -119,7 +120,11 @@ class m190417_202153_migrateDataToTable extends Migration
    */
   private function updateLinkField(LinkField $field, string $table, string $handlePrefix = ''): void {
     $insertRows = [];
+    $columnsToDrop = [];
     $columnName = ($field->columnPrefix ?: 'field_') . $handlePrefix . $field->handle;
+    if (!$this->db->tableExists($table)) {
+      return;
+    }
     if ($field->columnSuffix) {
       $columnName .= '_' . $field->columnSuffix;
     }
@@ -132,55 +137,77 @@ class m190417_202153_migrateDataToTable extends Migration
       }
     };
 
-    // Make sure the rows actually exist in the elements table.
-    $rows = (new Query())
-      ->select(['t.elementId', 't.siteId', 't.'.$columnName])
-      ->from(['t' => $table])
-      ->innerJoin(['e' => Table::ELEMENTS], '[[t.elementId]] = [[e.id]]')
-      ->all();
+    $yiiTable = Yii::$app->db->schema->getTableSchema($table);
+    if (isset($yiiTable->columns[$columnName])) {
+      // do something
 
-    foreach ($rows as $row) {
-      $payload = Json::decode($row[$columnName]);
-      if (!is_array($payload)) {
-        continue;
-      }
 
-      $type = $payload['type'] ?? null;
-      $value = $payload['value'] ?? '';
-      unset($payload['type']);
-      unset($payload['value']);
+      // Make sure the rows actually exist in the elements table.
+      $rowQuery = (new Query())
+        ->select(['t.elementId', 't.siteId', 't.'.$columnName])
+        ->from(['t' => $table])
+        ->innerJoin(['e' => Table::ELEMENTS], '[[t.elementId]] = [[e.id]]');
+      $rows = $rowQuery->all();
 
-      if ($value && is_numeric($value)) {
-        $doesExist = (new Query())
-          ->select('id')
-          ->where(['id' => $value])
-          ->from('{{%elements}}')
-          ->exists();
+      foreach ($rows as $row) {
 
-        if (!$doesExist) {
-          $value = null;
+        if (substr($row[$columnName], 0, 1) != "{") {
+          continue;
         }
-      }
 
-      $insertRows[] = [
-        $row['elementId'],                          // elementId
-        $row['siteId'],                             // siteId
-        $field->id,                                 // fieldId
-        is_numeric($value) ? $value : null,         // linkedId
-        is_numeric($value) ? $row['siteId'] : null, // linkedSiteId
-        $type,                                      // type
-        is_numeric($value) ? null : $value,         // linkedUrl
-        Json::encode($payload)                      // payload
-      ];
+        $payload = Json::decode((string)$row[$columnName], $associative=true, $depth=512, JSON_THROW_ON_ERROR);
 
-      if (count($insertRows) > 100) {
-        $writeRows($insertRows);
-        $insertRows = [];
+        if (!is_array($payload)) {
+          continue;
+        }
+
+        $type = $payload['type'] ?? null;
+        $value = $payload['value'] ?? '';
+        unset($payload['type']);
+        unset($payload['value']);
+
+        if ($value && is_numeric($value)) {
+          $doesExist = (new Query())
+            ->select('id')
+            ->where(['id' => $value])
+            ->from('{{%elements}}')
+            ->exists();
+
+          if (!$doesExist) {
+            $value = null;
+          }
+        }
+
+        $insertRows[] = [
+          $row['elementId'],                          // elementId
+          $row['siteId'],                             // siteId
+          $field->id,                                 // fieldId
+          is_numeric($value) ? $value : null,         // linkedId
+          is_numeric($value) ? $row['siteId'] : null, // linkedSiteId
+          $type,                                      // type
+          is_numeric($value) ? null : $value,         // linkedUrl
+          Json::encode($payload)                      // payload
+        ];
+
+        if (count($insertRows) > 100) {
+          $writeRows($insertRows);
+          $insertRows = [];
+        }
+        if (!in_array($columnName, $columnsToDrop)) {
+          $columnsToDrop[] = $columnName;
+        }
       }
     }
 
     $writeRows($insertRows);
-    $this->dropColumn($table, $columnName);
+
+    foreach ($columnsToDrop as $col) {
+      $yiiTable = Yii::$app->db->schema->getTableSchema($table);
+      if (isset($yiiTable->columns[$columnName])) {
+        $this->dropColumn($table, $col);
+      }
+    }
+    //
   }
 
   /**

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -14,6 +14,7 @@ use lenz\craft\utils\foreignField\ForeignFieldModel;
 use lenz\craft\utils\helpers\ArrayHelper;
 use lenz\linkfield\fields\LinkField;
 use Twig\Markup;
+use lenz\linkfield\helpers\StringHelper;
 
 /**
  * Class Link
@@ -214,7 +215,7 @@ class Link extends ForeignFieldModel
       return null;
     }
 
-    return Template::raw(Html::tag('a', $text, $attributes));
+    return Template::raw(Html::tag('a', $text, StringHelper::sanitizeAttributes($attributes)));
   }
 
   /**
@@ -228,7 +229,7 @@ class Link extends ForeignFieldModel
     $attributes = $this->getRawLinkAttributes($extraAttributes);
     return Template::raw(is_null($attributes)
       ? ''
-      : Html::renderTagAttributes($attributes)
+      : Html::renderTagAttributes(StringHelper::sanitizeAttributes($attributes))
     );
   }
 
@@ -295,7 +296,7 @@ class Link extends ForeignFieldModel
       $attributes = array_merge($attributes, $extraAttributes);
     }
 
-    return $attributes;
+    return StringHelper::sanitizeAttributes($attributes);
   }
 
   /**


### PR DESCRIPTION
Bug triggered when value passed in getLink method is array like
{ class: ['class1', 'class2']}